### PR TITLE
We must sample from a sequence, not a set

### DIFF
--- a/chubs.py
+++ b/chubs.py
@@ -29,4 +29,4 @@ print("{} unique words in {} files ({:.1f} bits per word)"
       .format(len(words), len(wordlists), bpw))
 print("Requested {} bits; these {} word(s) have {:.1f} bits:"
       .format(bits, n, n * bpw))
-print(" ".join(random.SystemRandom().sample(words, n)))
+print(" ".join(random.SystemRandom().sample(sorted(words), n)))


### PR DESCRIPTION
As of Python 3.11, the population we sample from must be a sequence. Automatic conversion of sets to lists is no longer supported.

## Testing
- `python3 chubs.py 16 README.md`

------
https://chatgpt.com/codex/tasks/task_e_68573209fae483279004cb2250360bb8