### PR TITLE
Remove redundant PassphraseInfo member

### DIFF
--- a/chubs.py
+++ b/chubs.py
@@ -24,7 +24,6 @@ def load_words(wordlists):
 class PassphraseInfo(NamedTuple):
     count: int        # number of words we selected from
     bpw: float        # bits per word
-    n: int            # number of words in passphrase
     words: list[str]  # the passphrase
 
 
@@ -34,7 +33,7 @@ def generate(bits, wordlists, rnd):
     bpw = math.log(len(words), 2)
     n = math.ceil(bits / bpw)
     chosen = rnd.sample(sorted(words), n)
-    return PassphraseInfo(len(words), bpw, n, chosen)
+    return PassphraseInfo(len(words), bpw, chosen)
 
 
 def main(argv):
@@ -46,9 +45,10 @@ def main(argv):
             info.count, len(wordlists), info.bpw
         )
     )
+    n = len(info.words)
     print(
         "Requested {} bits; these {} word(s) have {:.1f} bits:".format(
-            bits, info.n, info.n * info.bpw
+            bits, n, n * info.bpw
         )
     )
     print(" ".join(info.words))

--- a/tests/test_chubs.py
+++ b/tests/test_chubs.py
@@ -30,13 +30,12 @@ def test_generate_calculates_n_and_sample(tmp_path):
     info = chubs.generate(10, [words_file], DummyRandom())
     assert info.count == 8
     assert math.isclose(info.bpw, 3.0)
-    assert info.n == 4
     assert info.words == sorted(set(words))[:4]
 
 
 def test_main_prints_expected(monkeypatch, capsys):
     def fake_generate(bits, wordlists, rnd):
-        return chubs.PassphraseInfo(10, 3.0, 4, ["a", "b", "c", "d"])
+        return chubs.PassphraseInfo(10, 3.0, ["a", "b", "c", "d"])
 
     monkeypatch.setattr(chubs, "generate", fake_generate)
     chubs.main(["10", "dummy.txt"])


### PR DESCRIPTION
## Summary
- drop `n` field from `PassphraseInfo`
- compute the word count using `len(info.words)`
- update tests for the new structure
- remove leftover assertion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68573e8a8e2c83278db9bdf190108936