### PR TITLE
Improve CLI arg parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Invoke it from the command line using the built in help for details:
 
     $ python3 chubs.py -h
 
-The basic usage remains simple:
+Basic usage:
 
     $ python3 chubs.py 64 some-long-text-file.txt
     5640 unique words in 1 files (12.5 bits per word)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ such as the one in the comic. They need to be generated with a
 computer; humans are hopelessly bad at coming up with a random
 sequence of words.
 
-Invoke it from the command line, like so:
+Invoke it from the command line using the built in help for details:
+
+    $ python3 chubs.py -h
+
+The basic usage remains simple:
 
     $ python3 chubs.py 64 some-long-text-file.txt
     5640 unique words in 1 files (12.5 bits per word)

--- a/chubs.py
+++ b/chubs.py
@@ -41,7 +41,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "bits", type=int, help="number of random bits for the passphrase"
+        "bits", type=int, help="the passphrase will have at least this many bits of entropy"
     )
     parser.add_argument(
         "wordlists",

--- a/chubs.py
+++ b/chubs.py
@@ -1,3 +1,4 @@
+import argparse
 import math
 import random
 import re
@@ -36,9 +37,25 @@ def generate(bits, wordlists, rnd):
     return PassphraseInfo(len(words), bpw, chosen)
 
 
-def main(argv):
-    bits = int(argv[0])
-    wordlists = argv[1:]
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "bits", type=int, help="number of random bits for the passphrase"
+    )
+    parser.add_argument(
+        "wordlists",
+        nargs="+",
+        metavar="WORDLIST",
+        help="path(s) to text files containing candidate words",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> None:
+    args = parse_args(argv)
+    bits = args.bits
+    wordlists = args.wordlists
     info = generate(bits, wordlists, random.SystemRandom())
     print(
         "{} unique words in {} files ({:.1f} bits per word)".format(

--- a/tests/test_chubs.py
+++ b/tests/test_chubs.py
@@ -46,3 +46,9 @@ def test_main_prints_expected(monkeypatch, capsys):
         "a b c d\n"
     )
     assert captured.out == expected
+
+
+def test_parse_args_returns_namespace():
+    args = chubs.parse_args(["20", "one.txt", "two.txt"])
+    assert args.bits == 20
+    assert args.wordlists == ["one.txt", "two.txt"]


### PR DESCRIPTION
## Summary
- parse command line arguments with `argparse`
- document the new usage
- test the parse_args helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685741e208708327976bb77b64ef1d0b