### PR TITLE
Integrate ruff into CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest
+          pip install pytest ruff
+      - name: Lint, format, and type-check with ruff
+        run: |
+          ruff check .
+          ruff format --check .
       - name: Run tests
         run: pytest

--- a/chubs.py
+++ b/chubs.py
@@ -8,6 +8,7 @@ from typing import NamedTuple
 # is horribly English-centric.
 word_re = re.compile(r"[a-z]*$")
 
+
 def load_words(wordlists):
     """Return a set of admissible words found in *wordlists*."""
     words = set()
@@ -22,8 +23,8 @@ def load_words(wordlists):
 
 
 class PassphraseInfo(NamedTuple):
-    count: int        # number of words we selected from
-    bpw: float        # bits per word
+    count: int  # number of words we selected from
+    bpw: float  # bits per word
     words: list[str]  # the passphrase
 
 
@@ -40,17 +41,9 @@ def main(argv):
     bits = int(argv[0])
     wordlists = argv[1:]
     info = generate(bits, wordlists, random.SystemRandom())
-    print(
-        "{} unique words in {} files ({:.1f} bits per word)".format(
-            info.count, len(wordlists), info.bpw
-        )
-    )
+    print(f"{info.count} unique words in {len(wordlists)} files ({info.bpw:.1f} bits per word)")
     n = len(info.words)
-    print(
-        "Requested {} bits; these {} word(s) have {:.1f} bits:".format(
-            bits, n, n * info.bpw
-        )
-    )
+    print(f"Requested {bits} bits; these {n} word(s) have {n * info.bpw:.1f} bits:")
     print(" ".join(info.words))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "TCH"]
+

--- a/tests/test_chubs.py
+++ b/tests/test_chubs.py
@@ -22,10 +22,7 @@ class DummyRandom:
 
 def test_generate_calculates_n_and_sample(tmp_path):
     words_file = tmp_path / "words.txt"
-    words = [
-        "alpha", "beta", "gamma", "delta",
-        "epsilon", "zeta", "eta", "theta",
-    ]
+    words = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"]
     words_file.write_text(" ".join(words))
     info = chubs.generate(10, [words_file], DummyRandom())
     assert info.count == 8


### PR DESCRIPTION
## Summary
- format code with `ruff`
- configure ruff in `pyproject.toml`
- lint, format, and type-check via ruff in CI
- convert print statements to f-strings

## Testing
- `ruff check .`
- `ruff format --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685741fc03648327a57d48986e28d543