### PR TITLE
Add type hints and enforce with ruff

### DIFF
--- a/chubs.py
+++ b/chubs.py
@@ -3,16 +3,17 @@ import math
 import random
 import re
 import sys
+from collections.abc import Iterable
 from typing import NamedTuple
 
 # Regular expression that defines what words are admissible; this one
 # is horribly English-centric.
-word_re = re.compile(r"[a-z]*$")
+word_re: re.Pattern[str] = re.compile(r"[a-z]*$")
 
 
-def load_words(wordlists):
+def load_words(wordlists: Iterable[str]) -> set[str]:
     """Return a set of admissible words found in *wordlists*."""
-    words = set()
+    words: set[str] = set()
     for wordlist in wordlists:
         with open(wordlist) as f:
             for line in f:
@@ -29,7 +30,7 @@ class PassphraseInfo(NamedTuple):
     words: list[str]  # the passphrase
 
 
-def generate(bits, wordlists, rnd):
+def generate(bits: int, wordlists: Iterable[str], rnd: random.Random) -> PassphraseInfo:
     """Generate a passphrase from *wordlists* with at least *bits* bits."""
     words = load_words(wordlists)
     bpw = math.log(len(words), 2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "TCH"]
+select = ["E", "F", "I", "UP", "TCH", "ANN"]
 

--- a/tests/test_chubs.py
+++ b/tests/test_chubs.py
@@ -2,12 +2,14 @@ import math
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add project root to sys.path so the tests can import the chubs module
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import chubs
 
 
-def test_load_words(tmp_path):
+def test_load_words(tmp_path: Path) -> None:
     words_file = tmp_path / "words.txt"
     words_file.write_text("Hello world\nBanana BANANA apple123 pineapple")
     result = chubs.load_words([words_file])
@@ -15,12 +17,12 @@ def test_load_words(tmp_path):
 
 
 class DummyRandom:
-    def sample(self, seq, n):
+    def sample(self, seq: list[str], n: int) -> list[str]:
         """Return the first *n* items to keep sampling deterministic."""
         return list(seq)[:n]
 
 
-def test_generate_calculates_n_and_sample(tmp_path):
+def test_generate_calculates_n_and_sample(tmp_path: Path) -> None:
     words_file = tmp_path / "words.txt"
     words = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"]
     words_file.write_text(" ".join(words))
@@ -30,8 +32,10 @@ def test_generate_calculates_n_and_sample(tmp_path):
     assert info.words == sorted(set(words))[:4]
 
 
-def test_main_prints_expected(monkeypatch, capsys):
-    def fake_generate(bits, wordlists, rnd):
+def test_main_prints_expected(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_generate(bits: int, wordlists: list[str], rnd: DummyRandom) -> chubs.PassphraseInfo:
         return chubs.PassphraseInfo(10, 3.0, ["a", "b", "c", "d"])
 
     monkeypatch.setattr(chubs, "generate", fake_generate)
@@ -45,7 +49,7 @@ def test_main_prints_expected(monkeypatch, capsys):
     assert captured.out == expected
 
 
-def test_parse_args_returns_namespace():
+def test_parse_args_returns_namespace() -> None:
     args = chubs.parse_args(["20", "one.txt", "two.txt"])
     assert args.bits == 20
     assert args.wordlists == ["one.txt", "two.txt"]


### PR DESCRIPTION
## Summary
- add full type annotations to `chubs.py`
- enforce annotation checks via ruff configuration
- annotate tests to satisfy ruff

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685749345a54832786527f1382831214