### PR TITLE
Switch CI to uv

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
+      - name: Install uv
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Install dependencies
         run: uv pip install pytest ruff
       - name: Lint, format, and type-check with ruff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest ruff
+        run: uv pip install pytest ruff
       - name: Lint, format, and type-check with ruff
         run: |
           ruff check .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
-      - name: Install uv
-        run: |
-          curl -Ls https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
       - name: Install dependencies
         run: uv pip install pytest ruff
       - name: Lint, format, and type-check with ruff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: uv pip install pytest ruff
+        run: uv pip install --system pytest ruff
       - name: Lint, format, and type-check with ruff
         run: |
           ruff check .


### PR DESCRIPTION
## Summary
- use `uv` to install dependencies in CI

## Testing
- `pytest -q`
- `ruff check .`
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_68574fb55f70832794b67851bacc96ef